### PR TITLE
Add sample code to save a frame to a file, sample cleanup (fix all warnings, remove unneeded casts, etc).

### DIFF
--- a/Win32CaptureSample/App.cpp
+++ b/Win32CaptureSample/App.cpp
@@ -70,7 +70,7 @@ void App::StartCaptureFromItem(GraphicsCaptureItem item)
 {
     m_capture = std::make_unique<SimpleCapture>(m_device, item);
 
-    m_capture->CaptureAFrame();
+    m_capture->SaveNextFrame();
 
     auto surface = m_capture->CreateSurface(m_compositor);
     m_brush.Surface(surface);

--- a/Win32CaptureSample/App.cpp
+++ b/Win32CaptureSample/App.cpp
@@ -56,9 +56,8 @@ GraphicsCaptureItem App::StartCaptureFromMonitorHandle(HMONITOR hmon)
 
 IAsyncOperation<GraphicsCaptureItem> App::StartCaptureWithPickerAsync()
 {
-    auto result = false;
     auto item = co_await m_picker.PickSingleItemAsync();
-    if (item != nullptr)
+    if (item)
     {
         StartCaptureFromItem(item);
     }
@@ -70,21 +69,20 @@ void App::StartCaptureFromItem(GraphicsCaptureItem item)
 {
     m_capture = std::make_unique<SimpleCapture>(m_device, item);
 
-    m_capture->SaveNextFrame();
-
     auto surface = m_capture->CreateSurface(m_compositor);
     m_brush.Surface(surface);
+
+    m_capture->SaveNextFrame();
 
     m_capture->StartCapture();
 }
 
 void App::StopCapture()
 {
-    if (m_capture != nullptr)
+    if (m_capture)
     {
         m_capture->Close();
         m_capture = nullptr;
-
         m_brush.Surface(nullptr);
     }
 }

--- a/Win32CaptureSample/App.cpp
+++ b/Win32CaptureSample/App.cpp
@@ -10,9 +10,7 @@ using namespace Windows::UI;
 using namespace Windows::UI::Composition;
 using namespace Windows::Graphics::Capture;
 
-App::App(
-    ContainerVisual root,
-    GraphicsCapturePicker picker)
+App::App(ContainerVisual root, GraphicsCapturePicker picker)
 {
     m_picker = picker;
 
@@ -45,18 +43,14 @@ App::App(
 GraphicsCaptureItem App::StartCaptureFromWindowHandle(HWND hwnd)
 {
     auto item = CreateCaptureItemForWindow(hwnd);
-
     StartCaptureFromItem(item);
-
     return item;
 }
 
 GraphicsCaptureItem App::StartCaptureFromMonitorHandle(HMONITOR hmon)
 {
     auto item = CreateCaptureItemForMonitor(hmon);
-
     StartCaptureFromItem(item);
-
     return item;
 }
 
@@ -64,7 +58,6 @@ IAsyncOperation<GraphicsCaptureItem> App::StartCaptureWithPickerAsync()
 {
     auto result = false;
     auto item = co_await m_picker.PickSingleItemAsync();
-
     if (item != nullptr)
     {
         StartCaptureFromItem(item);
@@ -73,10 +66,11 @@ IAsyncOperation<GraphicsCaptureItem> App::StartCaptureWithPickerAsync()
     co_return item;
 }
 
-void App::StartCaptureFromItem(
-    GraphicsCaptureItem item)
+void App::StartCaptureFromItem(GraphicsCaptureItem item)
 {
     m_capture = std::make_unique<SimpleCapture>(m_device, item);
+
+    m_capture->CaptureAFrame();
 
     auto surface = m_capture->CreateSurface(m_compositor);
     m_brush.Surface(surface);

--- a/Win32CaptureSample/EnumerationMonitor.cpp
+++ b/Win32CaptureSample/EnumerationMonitor.cpp
@@ -1,31 +1,23 @@
 #include "pch.h"
 #include "EnumerationMonitor.h"
 
-BOOL CALLBACK EnumDisplayMonitorsProc(HMONITOR hmon, HDC, LPRECT, LPARAM lparam)
-{
-    MONITORINFOEX monitorInfo = {};
-    monitorInfo.cbSize = sizeof(MONITORINFOEX);
-    if (!GetMonitorInfo(hmon, &monitorInfo))
-    {
-        winrt::check_hresult(GetLastError());
-    }
-
-    std::wstring displayName(monitorInfo.szDevice);
-
-    std::vector<EnumerationMonitor>& monitors = *reinterpret_cast<std::vector<EnumerationMonitor>*>(lparam);
-    monitors.push_back(EnumerationMonitor(hmon, displayName));
-
-    return TRUE;
-}
-
-const std::vector<EnumerationMonitor> EnumerateMonitors()
-{
-    std::vector<EnumerationMonitor> monitors;
-    EnumDisplayMonitors(NULL, NULL, EnumDisplayMonitorsProc, reinterpret_cast<LPARAM>(&monitors));
-    return monitors;
-}
-
 std::vector<EnumerationMonitor> EnumerationMonitor::EnumerateAllMonitors()
 {
-    return EnumerateMonitors();
+    std::vector<EnumerationMonitor> monitors;
+    EnumDisplayMonitors(nullptr, nullptr, [](HMONITOR hmon, HDC, LPRECT, LPARAM lparam)
+    {
+        MONITORINFOEX monitorInfo = { sizeof(monitorInfo) };
+        if (!GetMonitorInfoW(hmon, &monitorInfo))
+        {
+            winrt::check_hresult(GetLastError());
+        }
+
+        std::wstring displayName(monitorInfo.szDevice);
+
+        auto& monitors = *reinterpret_cast<std::vector<EnumerationMonitor>*>(lparam);
+        monitors.push_back({ hmon, displayName });
+
+        return TRUE;
+    }, reinterpret_cast<LPARAM>(&monitors));
+    return monitors;
 }

--- a/Win32CaptureSample/EnumerationMonitor.h
+++ b/Win32CaptureSample/EnumerationMonitor.h
@@ -3,19 +3,16 @@
 struct EnumerationMonitor
 {
 public:
-    EnumerationMonitor(nullptr_t) {}
-    EnumerationMonitor(HMONITOR hmon, std::wstring& displayName)
-    {
-        m_hmon = hmon;
-        m_displayName = displayName;
-    }
+    static std::vector<EnumerationMonitor> EnumerateAllMonitors();
 
     HMONITOR Hmon() const noexcept { return m_hmon; }
     std::wstring DisplayName() const noexcept { return m_displayName; }
 
-    static std::vector<EnumerationMonitor> EnumerateAllMonitors();
-
 private:
-    HMONITOR m_hmon;
-    std::wstring m_displayName;
+    EnumerationMonitor(HMONITOR hmon, const std::wstring& displayName) : m_hmon(hmon), m_displayName(displayName)
+    {
+    }
+
+    const HMONITOR m_hmon;
+    const std::wstring m_displayName;
 };

--- a/Win32CaptureSample/EnumerationWindow.h
+++ b/Win32CaptureSample/EnumerationWindow.h
@@ -3,22 +3,18 @@
 struct EnumerationWindow
 {
 public:
-    EnumerationWindow(nullptr_t) {}
-    EnumerationWindow(HWND hwnd, std::wstring& title, std::wstring& className)
-    {
-        m_hwnd = hwnd;
-        m_title = title;
-        m_className = className;
-    }
+    static std::vector<EnumerationWindow> EnumerateAllWindows();
 
     HWND Hwnd() const noexcept { return m_hwnd; }
     std::wstring Title() const noexcept { return m_title; }
     std::wstring ClassName() const noexcept { return m_className; }
 
-    static std::vector<EnumerationWindow> EnumerateAllWindows();
-
 private:
-    HWND m_hwnd;
-    std::wstring m_title;
-    std::wstring m_className;
+    EnumerationWindow(HWND hwnd, const std::wstring& title, const std::wstring& className) : 
+        m_hwnd(hwnd), m_title(title), m_className(className)
+    {
+    }
+    const HWND m_hwnd;
+    const std::wstring m_title;
+    const std::wstring m_className;
 };

--- a/Win32CaptureSample/SampleWindow.cpp
+++ b/Win32CaptureSample/SampleWindow.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "App.h"
 #include "SampleWindow.h"
-
 #include <CommCtrl.h>
 
 using namespace winrt;
@@ -108,6 +107,8 @@ fire_and_forget SampleWindow::OnPickerButtonClicked()
     }
 }
 
+// Not DPI aware but could be by multiplying the constants based on the monitor scale factor
+
 void SampleWindow::CreateControls(HINSTANCE instance)
 {
     auto isWin32ProgrammaticPresent = winrt::Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", 8);
@@ -122,7 +123,7 @@ void SampleWindow::CreateControls(HINSTANCE instance)
     // Populate window combo box
     for (auto& window : m_windows)
     {
-        SendMessage(windowComboBoxHwnd, CB_ADDSTRING, 0, (LPARAM)window.Title().c_str());
+        SendMessageW(windowComboBoxHwnd, CB_ADDSTRING, 0, (LPARAM)window.Title().c_str());
     }
 
     // Create monitor combo box
@@ -134,7 +135,7 @@ void SampleWindow::CreateControls(HINSTANCE instance)
     // Populate monitor combo box
     for (auto& monitor : m_monitors)
     {
-        SendMessage(monitorComboBoxHwnd, CB_ADDSTRING, 0, (LPARAM)monitor.DisplayName().c_str());
+        SendMessageW(monitorComboBoxHwnd, CB_ADDSTRING, 0, (LPARAM)monitor.DisplayName().c_str());
     }
 
     // Create picker button

--- a/Win32CaptureSample/SampleWindow.cpp
+++ b/Win32CaptureSample/SampleWindow.cpp
@@ -11,40 +11,22 @@ using namespace Windows::UI;
 using namespace Windows::UI::Composition;
 using namespace Windows::UI::Composition::Desktop;
 
-SampleWindow::SampleWindow(
-    HINSTANCE instance,
-    int cmdShow,
-    std::shared_ptr<App> app)
+SampleWindow::SampleWindow(HINSTANCE instance, int cmdShow, std::shared_ptr<App> app)
 {
-    WNDCLASSEX wcex = {};
-    wcex.cbSize = sizeof(WNDCLASSEX);
+    WNDCLASSEX wcex = { sizeof(wcex) };
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = instance;
-    wcex.hIcon = LoadIcon(instance, MAKEINTRESOURCE(IDI_APPLICATION));
-    wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wcex.hIcon = LoadIconW(instance, IDI_APPLICATION);
+    wcex.hCursor = LoadCursorW(nullptr, IDC_ARROW);
     wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
-    wcex.lpszMenuName = NULL;
     wcex.lpszClassName = L"Win32CaptureSample";
-    wcex.hIconSm = LoadIcon(wcex.hInstance, MAKEINTRESOURCE(IDI_APPLICATION));
-    WINRT_VERIFY(RegisterClassEx(&wcex));
+    wcex.hIconSm = LoadIconW(wcex.hInstance, IDI_APPLICATION);
+    WINRT_VERIFY(RegisterClassExW(&wcex));
     WINRT_ASSERT(!m_window);
 
-    WINRT_VERIFY(CreateWindow(
-        L"Win32CaptureSample",
-        L"Win32CaptureSample",
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        800,
-        600,
-        NULL,
-        NULL,
-        instance,
-        this));
-
+    WINRT_VERIFY(CreateWindowW(L"Win32CaptureSample", L"Win32CaptureSample", WS_OVERLAPPEDWINDOW, 
+        CW_USEDEFAULT, CW_USEDEFAULT, 800, 600, nullptr, nullptr, instance, this));
     WINRT_ASSERT(m_window);
 
     ShowWindow(m_window, cmdShow);
@@ -69,7 +51,7 @@ LRESULT SampleWindow::MessageHandler(UINT const message, WPARAM const wparam, LP
             {
             case CBN_SELCHANGE:
                 {
-                    auto index = SendMessage(hwnd, CB_GETCURSEL, 0, 0);
+                    auto index = SendMessageW(hwnd, CB_GETCURSEL, 0, 0);
                     if (hwnd == m_windowComboBoxHwnd)
                     {
                         auto window = m_windows[index];
@@ -84,7 +66,7 @@ LRESULT SampleWindow::MessageHandler(UINT const message, WPARAM const wparam, LP
                         auto item = m_app->StartCaptureFromMonitorHandle(monitor.Hmon());
 
                         SetSubTitle(std::wstring(item.DisplayName()));
-                        SendMessage(m_windowComboBoxHwnd, CB_SETCURSEL, -1, 0);
+                        SendMessageW(m_windowComboBoxHwnd, CB_SETCURSEL, -1, 0);
                     }
                 }
                 break;
@@ -98,8 +80,8 @@ LRESULT SampleWindow::MessageHandler(UINT const message, WPARAM const wparam, LP
                     {
                         m_app->StopCapture();
                         SetSubTitle(L"");
-                        SendMessage(m_monitorComboBoxHwnd, CB_SETCURSEL, -1, 0);
-                        SendMessage(m_windowComboBoxHwnd, CB_SETCURSEL, -1, 0);
+                        SendMessageW(m_monitorComboBoxHwnd, CB_SETCURSEL, -1, 0);
+                        SendMessageW(m_windowComboBoxHwnd, CB_SETCURSEL, -1, 0);
                     }
                 }
                 break;
@@ -121,8 +103,8 @@ fire_and_forget SampleWindow::OnPickerButtonClicked()
     if (selectedItem)
     {
         SetSubTitle(std::wstring(selectedItem.DisplayName()));
-        SendMessage(m_monitorComboBoxHwnd, CB_SETCURSEL, -1, 0);
-        SendMessage(m_windowComboBoxHwnd, CB_SETCURSEL, -1, 0);
+        SendMessageW(m_monitorComboBoxHwnd, CB_SETCURSEL, -1, 0);
+        SendMessageW(m_windowComboBoxHwnd, CB_SETCURSEL, -1, 0);
     }
 }
 
@@ -132,18 +114,9 @@ void SampleWindow::CreateControls(HINSTANCE instance)
     auto win32ProgrammaticStyle = isWin32ProgrammaticPresent ? 0 : WS_DISABLED;
 
     // Create window combo box
-    HWND windowComboBoxHwnd = CreateWindow(
-        WC_COMBOBOX,
-        L"",
+    HWND windowComboBoxHwnd = CreateWindowW(WC_COMBOBOX, L"",
         CBS_DROPDOWNLIST | CBS_HASSTRINGS | WS_VSCROLL | WS_CHILD | WS_OVERLAPPED | WS_VISIBLE | win32ProgrammaticStyle,
-        10,
-        10,
-        200,
-        200,
-        m_window,
-        NULL,
-        instance,
-        NULL);
+        10, 10, 200, 200, m_window, nullptr, instance, nullptr);
     WINRT_VERIFY(windowComboBoxHwnd);
 
     // Populate window combo box
@@ -153,18 +126,9 @@ void SampleWindow::CreateControls(HINSTANCE instance)
     }
 
     // Create monitor combo box
-    HWND monitorComboBoxHwnd = CreateWindow(
-        WC_COMBOBOX,
-        L"",
+    HWND monitorComboBoxHwnd = CreateWindowW(WC_COMBOBOX, L"",
         CBS_DROPDOWNLIST | CBS_HASSTRINGS | WS_VSCROLL | WS_CHILD | WS_OVERLAPPED | WS_VISIBLE | win32ProgrammaticStyle,
-        10,
-        45,
-        200,
-        200,
-        m_window,
-        NULL,
-        instance,
-        NULL);
+        10, 45, 200, 200, m_window, nullptr, instance, nullptr);
     WINRT_VERIFY(monitorComboBoxHwnd);
 
     // Populate monitor combo box
@@ -174,33 +138,15 @@ void SampleWindow::CreateControls(HINSTANCE instance)
     }
 
     // Create picker button
-    HWND pickerButtonHwnd = CreateWindow(
-        WC_BUTTON,
-        L"Use Picker",
+    HWND pickerButtonHwnd = CreateWindowW(WC_BUTTON, L"Use Picker",
         WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
-        10,
-        80,
-        200,
-        30,
-        m_window,
-        NULL,
-        instance,
-        NULL);
+        10, 80, 200, 30, m_window, nullptr, instance, nullptr);
     WINRT_VERIFY(pickerButtonHwnd);
 
     // Create picker button
-    HWND stopButtonHwnd = CreateWindow(
-        WC_BUTTON,
-        L"Stop Capture",
+    HWND stopButtonHwnd = CreateWindowW(WC_BUTTON, L"Stop Capture",
         WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
-        10,
-        120,
-        200,
-        30,
-        m_window,
-        NULL,
-        instance,
-        NULL);
+        10, 120, 200, 30, m_window, nullptr, instance, nullptr);
     WINRT_VERIFY(stopButtonHwnd);
 
     m_windowComboBoxHwnd = windowComboBoxHwnd;
@@ -209,12 +155,12 @@ void SampleWindow::CreateControls(HINSTANCE instance)
     m_stopButtonHwnd = stopButtonHwnd;
 }
 
-void SampleWindow::SetSubTitle(std::wstring text)
+void SampleWindow::SetSubTitle(const std::wstring& text)
 {
     std::wstring titleText(L"Win32CaptureSample");
     if (!text.empty())
     {
         titleText += (L" - " + text);
     }
-    SetWindowText(m_window, titleText.c_str());
+    SetWindowTextW(m_window, titleText.c_str());
 }

--- a/Win32CaptureSample/SampleWindow.h
+++ b/Win32CaptureSample/SampleWindow.h
@@ -14,7 +14,7 @@ struct SampleWindow : DesktopWindow<SampleWindow>
         return CreateDesktopWindowTarget(compositor, m_window, true);
     }
 
-    void InitializeObejctWithWindowHandle(winrt::Windows::Foundation::IUnknown const& object)
+    void InitializeObjectWithWindowHandle(winrt::Windows::Foundation::IUnknown const& object)
     {
         auto initializer = object.as<IInitializeWithWindow>();
         winrt::check_hresult(initializer->Initialize(m_window));

--- a/Win32CaptureSample/SampleWindow.h
+++ b/Win32CaptureSample/SampleWindow.h
@@ -14,7 +14,7 @@ struct SampleWindow : DesktopWindow<SampleWindow>
         return CreateDesktopWindowTarget(compositor, m_window, true);
     }
 
-    void Initialize(winrt::Windows::Foundation::IUnknown const& object)
+    void InitializeObejctWithWindowHandle(winrt::Windows::Foundation::IUnknown const& object)
     {
         auto initializer = object.as<IInitializeWithWindow>();
         winrt::check_hresult(initializer->Initialize(m_window));

--- a/Win32CaptureSample/SampleWindow.h
+++ b/Win32CaptureSample/SampleWindow.h
@@ -24,14 +24,13 @@ struct SampleWindow : DesktopWindow<SampleWindow>
 
 private:
     void CreateControls(HINSTANCE instance);
-    void SetSubTitle(std::wstring text);
+    void SetSubTitle(const std::wstring& text);
     winrt::fire_and_forget OnPickerButtonClicked();
 
-private:
-    HWND m_windowComboBoxHwnd = NULL;
-    HWND m_monitorComboBoxHwnd = NULL;
-    HWND m_pickerButtonHwnd = NULL;
-    HWND m_stopButtonHwnd = NULL;
+    HWND m_windowComboBoxHwnd = nullptr;
+    HWND m_monitorComboBoxHwnd = nullptr;
+    HWND m_pickerButtonHwnd = nullptr;
+    HWND m_stopButtonHwnd = nullptr;
     std::vector<EnumerationWindow> m_windows;
     std::vector<EnumerationMonitor> m_monitors;
     std::shared_ptr<App> m_app;

--- a/Win32CaptureSample/SimpleCapture.cpp
+++ b/Win32CaptureSample/SimpleCapture.cpp
@@ -77,7 +77,6 @@ bool SimpleCapture::TryResizeSwapChain(const winrt::Windows::Graphics::Capture::
     return false;
 }
 
-
 void SimpleCapture::OnFrameArrived(Direct3D11CaptureFramePool const& sender, winrt::Windows::Foundation::IInspectable const&)
 {
     auto newSize = false;

--- a/Win32CaptureSample/SimpleCapture.h
+++ b/Win32CaptureSample/SimpleCapture.h
@@ -12,7 +12,7 @@ public:
     winrt::Windows::UI::Composition::ICompositionSurface CreateSurface(
         winrt::Windows::UI::Composition::Compositor const& compositor);
 
-    void CaptureAFrame();
+    void SaveNextFrame() { m_captureNextImage = true; }
 
     void Close();
 
@@ -42,4 +42,5 @@ private:
     winrt::com_ptr<ID3D11DeviceContext> m_d3dContext{ nullptr };
 
     std::atomic<bool> m_closed = false;
+    std::atomic<bool> m_captureNextImage = false;
 };

--- a/Win32CaptureSample/SimpleCapture.h
+++ b/Win32CaptureSample/SimpleCapture.h
@@ -12,6 +12,8 @@ public:
     winrt::Windows::UI::Composition::ICompositionSurface CreateSurface(
         winrt::Windows::UI::Composition::Compositor const& compositor);
 
+    void CaptureAFrame();
+
     void Close();
 
 private:
@@ -26,6 +28,8 @@ private:
             throw winrt::hresult_error(RO_E_CLOSED);
         }
     }
+
+    bool TryResizeSwapChain(const winrt::Windows::Graphics::Capture::Direct3D11CaptureFrame& frame);
 
 private:
     winrt::Windows::Graphics::Capture::GraphicsCaptureItem m_item{ nullptr };

--- a/Win32CaptureSample/Win32CaptureSample.vcxproj
+++ b/Win32CaptureSample/Win32CaptureSample.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -163,13 +163,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/Win32CaptureSample/Win32CaptureSample.vcxproj
+++ b/Win32CaptureSample/Win32CaptureSample.vcxproj
@@ -164,6 +164,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\directxtex_desktop_win10.2019.5.31.1\build\native\directxtex_desktop_win10.targets" Condition="Exists('..\packages\directxtex_desktop_win10.2019.5.31.1\build\native\directxtex_desktop_win10.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -171,5 +172,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_desktop_win10.2019.5.31.1\build\native\directxtex_desktop_win10.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_desktop_win10.2019.5.31.1\build\native\directxtex_desktop_win10.targets'))" />
   </Target>
 </Project>

--- a/Win32CaptureSample/capture.interop.h
+++ b/Win32CaptureSample/capture.interop.h
@@ -12,26 +12,23 @@ struct __declspec(uuid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1"))
 
 inline auto CreateCaptureItemForWindow(HWND hwnd)
 {
-    auto activation_factory = winrt::get_activation_factory<winrt::Windows::Graphics::Capture::GraphicsCaptureItem>();
-    auto interop_factory = activation_factory.as<IGraphicsCaptureItemInterop>();
+    auto interop_factory = winrt::get_activation_factory<winrt::Windows::Graphics::Capture::GraphicsCaptureItem, IGraphicsCaptureItemInterop>();
     winrt::Windows::Graphics::Capture::GraphicsCaptureItem item = { nullptr };
-    winrt::check_hresult(interop_factory->CreateForWindow(hwnd, winrt::guid_of<ABI::Windows::Graphics::Capture::IGraphicsCaptureItem>(), reinterpret_cast<void**>(winrt::put_abi(item))));
+    winrt::check_hresult(interop_factory->CreateForWindow(hwnd, winrt::guid_of<ABI::Windows::Graphics::Capture::IGraphicsCaptureItem>(), winrt::put_abi(item)));
     return item;
 }
 
 inline auto CreateCaptureItemForMonitor(HMONITOR hmon)
 {
-    auto activation_factory = winrt::get_activation_factory<winrt::Windows::Graphics::Capture::GraphicsCaptureItem>();
-    auto interop_factory = activation_factory.as<IGraphicsCaptureItemInterop>();
+    auto interop_factory = winrt::get_activation_factory<winrt::Windows::Graphics::Capture::GraphicsCaptureItem, IGraphicsCaptureItemInterop>();
     winrt::Windows::Graphics::Capture::GraphicsCaptureItem item = { nullptr };
-    winrt::check_hresult(interop_factory->CreateForMonitor(hmon, winrt::guid_of<ABI::Windows::Graphics::Capture::IGraphicsCaptureItem>(), reinterpret_cast<void**>(winrt::put_abi(item))));
+    winrt::check_hresult(interop_factory->CreateForMonitor(hmon, winrt::guid_of<ABI::Windows::Graphics::Capture::IGraphicsCaptureItem>(), winrt::put_abi(item)));
     return item;
 }
 
 inline auto CreateCapturePickerForHwnd(HWND hwnd)
 {
     auto picker = winrt::Windows::Graphics::Capture::GraphicsCapturePicker();
-    auto initializer = picker.as<IInitializeWithWindow>();
-    winrt::check_hresult(initializer->Initialize(hwnd));
+    winrt::check_hresult(picker.as<IInitializeWithWindow>()->Initialize(hwnd));
     return picker;
 }

--- a/Win32CaptureSample/composition.interop.h
+++ b/Win32CaptureSample/composition.interop.h
@@ -27,6 +27,12 @@ inline void ResizeSurface(
     winrt::check_hresult(surfaceInterop->Resize(newSize));
 }
 
+// Do the type conversion from long -> float without warnings
+inline D2D1::Matrix3x2F Translation(const POINT& pt)
+{
+    return D2D1::Matrix3x2F::Translation(static_cast<float>(pt.x), static_cast<float>(pt.y));
+}
+
 inline auto SurfaceBeginDraw(
     winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface)
 {
@@ -34,7 +40,7 @@ inline auto SurfaceBeginDraw(
     winrt::com_ptr<ID2D1DeviceContext> context;
     POINT offset = {};
     winrt::check_hresult(surfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), context.put_void(), &offset));
-    context->SetTransform(D2D1::Matrix3x2F::Translation(offset.x, offset.y));
+    context->SetTransform(Translation(offset));
     return context;
 }
 

--- a/Win32CaptureSample/composition.interop.h
+++ b/Win32CaptureSample/composition.interop.h
@@ -3,28 +3,22 @@
 #include <windows.ui.composition.interop.h>
 #include <d2d1_1.h>
 
-inline auto CreateCompositionGraphicsDevice(
-    winrt::Windows::UI::Composition::Compositor const& compositor,
-    ::IUnknown* device)
+inline auto CreateCompositionGraphicsDevice(winrt::Windows::UI::Composition::Compositor const& compositor, ::IUnknown* device)
 {
     winrt::Windows::UI::Composition::CompositionGraphicsDevice graphicsDevice{ nullptr };
     auto compositorInterop = compositor.as<ABI::Windows::UI::Composition::ICompositorInterop>();
     winrt::com_ptr<ABI::Windows::UI::Composition::ICompositionGraphicsDevice> graphicsInterop;
     winrt::check_hresult(compositorInterop->CreateGraphicsDevice(device, graphicsInterop.put()));
     winrt::check_hresult(graphicsInterop->QueryInterface(winrt::guid_of<winrt::Windows::UI::Composition::CompositionGraphicsDevice>(),
-        reinterpret_cast<void**>(winrt::put_abi(graphicsDevice))));
+        winrt::put_abi(graphicsDevice)));
     return graphicsDevice;
 }
 
-inline void ResizeSurface(
-    winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface,
+inline void ResizeSurface(winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface,
     winrt::Windows::Foundation::Size const& size)
 {
     auto surfaceInterop = surface.as<ABI::Windows::UI::Composition::ICompositionDrawingSurfaceInterop>();
-    SIZE newSize = {};
-    newSize.cx = static_cast<LONG>(std::round(size.Width));
-    newSize.cy = static_cast<LONG>(std::round(size.Height));
-    winrt::check_hresult(surfaceInterop->Resize(newSize));
+    winrt::check_hresult(surfaceInterop->Resize({ static_cast<LONG>(std::round(size.Width)), static_cast<LONG>(std::round(size.Height)) }));
 }
 
 // Do the type conversion from long -> float without warnings
@@ -33,46 +27,38 @@ inline D2D1::Matrix3x2F Translation(const POINT& pt)
     return D2D1::Matrix3x2F::Translation(static_cast<float>(pt.x), static_cast<float>(pt.y));
 }
 
-inline auto SurfaceBeginDraw(
-    winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface)
+inline auto SurfaceBeginDraw(winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface)
 {
     auto surfaceInterop = surface.as<ABI::Windows::UI::Composition::ICompositionDrawingSurfaceInterop>();
     winrt::com_ptr<ID2D1DeviceContext> context;
     POINT offset = {};
-    winrt::check_hresult(surfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), context.put_void(), &offset));
+    winrt::check_hresult(surfaceInterop->BeginDraw(nullptr, __uuidof(context), context.put_void(), &offset));
     context->SetTransform(Translation(offset));
     return context;
 }
 
-inline void SurfaceEndDraw(
-    winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface)
+inline void SurfaceEndDraw(winrt::Windows::UI::Composition::CompositionDrawingSurface const& surface)
 {
     auto surfaceInterop = surface.as<ABI::Windows::UI::Composition::ICompositionDrawingSurfaceInterop>();
     winrt::check_hresult(surfaceInterop->EndDraw());
 }
 
-inline auto CreateCompositionSurfaceForSwapChain(
-    winrt::Windows::UI::Composition::Compositor const& compositor,
-    ::IUnknown* swapChain)
+inline auto CreateCompositionSurfaceForSwapChain(winrt::Windows::UI::Composition::Compositor const& compositor, ::IUnknown* swapChain)
 {
     winrt::Windows::UI::Composition::ICompositionSurface surface{ nullptr };
     auto compositorInterop = compositor.as<ABI::Windows::UI::Composition::ICompositorInterop>();
     winrt::com_ptr<ABI::Windows::UI::Composition::ICompositionSurface> surfaceInterop;
     winrt::check_hresult(compositorInterop->CreateCompositionSurfaceForSwapChain(swapChain, surfaceInterop.put()));
-    winrt::check_hresult(surfaceInterop->QueryInterface(winrt::guid_of<winrt::Windows::UI::Composition::ICompositionSurface>(),
-        reinterpret_cast<void**>(winrt::put_abi(surface))));
+    winrt::check_hresult(surfaceInterop->QueryInterface(winrt::guid_of<winrt::Windows::UI::Composition::ICompositionSurface>(), winrt::put_abi(surface)));
     return surface;
 }
 
-inline auto CreateDesktopWindowTarget(
-    winrt::Windows::UI::Composition::Compositor const& compositor,
-    HWND window,
-    bool isTopMost)
+inline auto CreateDesktopWindowTarget(winrt::Windows::UI::Composition::Compositor const& compositor, HWND window, bool isTopMost)
 {
     namespace abi = ABI::Windows::UI::Composition::Desktop;
 
     auto interop = compositor.as<abi::ICompositorDesktopInterop>();
     winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget target{ nullptr };
-    winrt::check_hresult(interop->CreateDesktopWindowTarget(window, isTopMost, reinterpret_cast<abi::IDesktopWindowTarget * *>(winrt::put_abi(target))));
+    winrt::check_hresult(interop->CreateDesktopWindowTarget(window, isTopMost, reinterpret_cast<abi::IDesktopWindowTarget**>(winrt::put_abi(target))));
     return target;
 }

--- a/Win32CaptureSample/d3dHelpers.h
+++ b/Win32CaptureSample/d3dHelpers.h
@@ -43,35 +43,19 @@ private:
     winrt::com_ptr<ID3D11Multithread> m_multithread;
 };
 
-inline auto
-CreateWICFactory()
+inline auto CreateWICFactory()
 {
-    winrt::com_ptr<IWICImagingFactory2> wicFactory;
-    winrt::check_hresult(
-        ::CoCreateInstance(
-            CLSID_WICImagingFactory,
-            nullptr,
-            CLSCTX_INPROC_SERVER,
-            winrt::guid_of<IWICImagingFactory>(),
-            wicFactory.put_void()));
-
-    return wicFactory;
+    return winrt::create_instance<IWICImagingFactory2>(CLSID_WICImagingFactory);
 }
 
-inline auto
-CreateD2DDevice(
-    winrt::com_ptr<ID2D1Factory1> const& factory,
-    winrt::com_ptr<ID3D11Device> const& device)
+inline auto CreateD2DDevice(winrt::com_ptr<ID2D1Factory1> const& factory, winrt::com_ptr<ID3D11Device> const& device)
 {
     winrt::com_ptr<ID2D1Device> result;
     winrt::check_hresult(factory->CreateDevice(device.as<IDXGIDevice>().get(), result.put()));
     return result;
 }
 
-inline auto
-CreateD3DDevice(
-    D3D_DRIVER_TYPE const type,
-    winrt::com_ptr<ID3D11Device>& device)
+inline auto CreateD3DDevice(D3D_DRIVER_TYPE const type, winrt::com_ptr<ID3D11Device>& device)
 {
     WINRT_ASSERT(!device);
 
@@ -81,24 +65,14 @@ CreateD3DDevice(
 //	flags |= D3D11_CREATE_DEVICE_DEBUG;
 //#endif
 
-    return D3D11CreateDevice(
-        nullptr,
-        type,
-        nullptr,
-        flags,
-        nullptr, 0,
-        D3D11_SDK_VERSION,
-        device.put(),
-        nullptr,
-        nullptr);
+    return D3D11CreateDevice(nullptr, type, nullptr, flags, nullptr, 0, D3D11_SDK_VERSION, device.put(),
+        nullptr, nullptr);
 }
 
-inline auto
-CreateD3DDevice()
+inline auto CreateD3DDevice()
 {
     winrt::com_ptr<ID3D11Device> device;
     HRESULT hr = CreateD3DDevice(D3D_DRIVER_TYPE_HARDWARE, device);
-
     if (DXGI_ERROR_UNSUPPORTED == hr)
     {
         hr = CreateD3DDevice(D3D_DRIVER_TYPE_WARP, device);
@@ -108,8 +82,7 @@ CreateD3DDevice()
     return device;
 }
 
-inline auto
-CreateD2DFactory()
+inline auto CreateD2DFactory()
 {
     D2D1_FACTORY_OPTIONS options{};
 
@@ -118,19 +91,11 @@ CreateD2DFactory()
 //#endif
 
     winrt::com_ptr<ID2D1Factory1> factory;
-
-    winrt::check_hresult(D2D1CreateFactory(
-        D2D1_FACTORY_TYPE_SINGLE_THREADED,
-        options,
-        factory.put()));
-
+    winrt::check_hresult(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, options, factory.put()));
     return factory;
 }
 
-inline auto
-CreateDXGISwapChain(
-    winrt::com_ptr<ID3D11Device> const& device,
-    const DXGI_SWAP_CHAIN_DESC1* desc)
+inline auto CreateDXGISwapChain(winrt::com_ptr<ID3D11Device> const& device, const DXGI_SWAP_CHAIN_DESC1* desc)
 {
     auto dxgiDevice = device.as<IDXGIDevice2>();
     winrt::com_ptr<IDXGIAdapter> adapter;
@@ -139,22 +104,12 @@ CreateDXGISwapChain(
     winrt::check_hresult(adapter->GetParent(winrt::guid_of<IDXGIFactory2>(), factory.put_void()));
 
     winrt::com_ptr<IDXGISwapChain1> swapchain;
-    winrt::check_hresult(factory->CreateSwapChainForComposition(
-        device.get(),
-        desc,
-        nullptr,
-        swapchain.put()));
-
+    winrt::check_hresult(factory->CreateSwapChainForComposition(device.get(), desc, nullptr, swapchain.put()));
     return swapchain;
 }
 
-inline auto
-CreateDXGISwapChain(
-    winrt::com_ptr<ID3D11Device> const& device,
-    uint32_t width,
-    uint32_t height,
-    DXGI_FORMAT format,
-    uint32_t bufferCount)
+inline auto CreateDXGISwapChain(winrt::com_ptr<ID3D11Device> const& device,
+    uint32_t width, uint32_t height, DXGI_FORMAT format, uint32_t bufferCount)
 {
     DXGI_SWAP_CHAIN_DESC1 desc = {};
     desc.Width = width;

--- a/Win32CaptureSample/main.cpp
+++ b/Win32CaptureSample/main.cpp
@@ -43,7 +43,7 @@ int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
     auto window = SampleWindow(instance, cmdShow, app);
 
     // Provide the window handle to the picker (explict HWND initialization)
-    window.InitializeObejctWithWindowHandle(picker);
+    window.InitializeObjectWithWindowHandle(picker);
 
     // Hookup the visual tree to the window
     auto target = window.CreateWindowTarget(compositor);

--- a/Win32CaptureSample/main.cpp
+++ b/Win32CaptureSample/main.cpp
@@ -7,25 +7,18 @@ using namespace winrt;
 using namespace Windows::Graphics::Capture;
 using namespace Windows::UI::Composition;
 
-int __stdcall WinMain(
-    HINSTANCE instance,
-    HINSTANCE previousInstance,
-    LPSTR     cmdLine,
-    int       cmdShow)
+int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
 {
-    // Initialize COM
     init_apartment(apartment_type::single_threaded);
 
     // Check to see that capture is supported
     auto isCaptureSupported = winrt::Windows::Graphics::Capture::GraphicsCaptureSession::IsSupported();
     if (!isCaptureSupported)
     {
-        MessageBox(
-            NULL,
+        MessageBoxW(nullptr,
             L"Screen capture is not supported on this device for this release of Windows!",
             L"Win32CaptureSample",
             MB_OK | MB_ICONERROR);
-
         return 1;
     }
 
@@ -57,11 +50,11 @@ int __stdcall WinMain(
 
     // Message pump
     MSG msg;
-    while (GetMessage(&msg, NULL, 0, 0))
+    while (GetMessage(&msg, nullptr, 0, 0))
     {
         TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        DispatchMessageW(&msg);
     }
 
-    return msg.wParam;
+    return static_cast<int>(msg.wParam);
 }

--- a/Win32CaptureSample/main.cpp
+++ b/Win32CaptureSample/main.cpp
@@ -42,7 +42,7 @@ int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
 
     auto window = SampleWindow(instance, cmdShow, app);
 
-    // Provide the window handle to the picker (explict HWND initialization)
+    // Provide the window handle to the picker (explicit HWND initialization)
     window.InitializeObjectWithWindowHandle(picker);
 
     // Hookup the visual tree to the window
@@ -51,7 +51,7 @@ int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
 
     // Message pump
     MSG msg;
-    while (GetMessage(&msg, nullptr, 0, 0))
+    while (GetMessageW(&msg, nullptr, 0, 0))
     {
         TranslateMessage(&msg);
         DispatchMessageW(&msg);

--- a/Win32CaptureSample/main.cpp
+++ b/Win32CaptureSample/main.cpp
@@ -11,6 +11,8 @@ using namespace Windows::UI::Composition;
 
 int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
 {
+    // SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2); // works but everything draws small
+
     init_apartment(apartment_type::single_threaded);
 
     // Check to see that capture is supported
@@ -24,7 +26,7 @@ int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
         return 1;
     }
 
-    // Create a DispatcherQueue for our thread
+    // Create the DispatcherQueue that the compositor needs to run
     auto controller = CreateDispatcherQueueControllerForCurrentThread();
 
     // Initialize Composition
@@ -34,17 +36,14 @@ int __stdcall WinMain(HINSTANCE instance, HINSTANCE, PSTR cmdLine, int cmdShow)
     root.Size({ -220.0f, 0.0f });
     root.Offset({ 220.0f, 0.0f, 0.0f });
 
-    // Create the picker
     auto picker = GraphicsCapturePicker();
 
-    // Create the app
     auto app = std::make_shared<App>(root, picker);
 
-    // Create the window
     auto window = SampleWindow(instance, cmdShow, app);
 
-    // Initialize the picker with our window
-    window.Initialize(picker);
+    // Provide the window handle to the picker (explict HWND initialization)
+    window.InitializeObejctWithWindowHandle(picker);
 
     // Hookup the visual tree to the window
     auto target = window.CreateWindowTarget(compositor);

--- a/Win32CaptureSample/main.cpp
+++ b/Win32CaptureSample/main.cpp
@@ -3,6 +3,8 @@
 #include "App.h"
 #include "SampleWindow.h"
 
+#pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
+
 using namespace winrt;
 using namespace Windows::Graphics::Capture;
 using namespace Windows::UI::Composition;

--- a/Win32CaptureSample/packages.config
+++ b/Win32CaptureSample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.190620.2" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.190712.2" targetFramework="native" />
 </packages>

--- a/Win32CaptureSample/packages.config
+++ b/Win32CaptureSample/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="directxtex_desktop_win10" version="2019.5.31.1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190712.2" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Rob, please check the code in `SampleCapture.cpp` that uses DirectXTex CaptureTexture, SaveToWICFile. I want to make sure this is the best way to do this as I will share this with the team. In my testing this seems to work fine. 

See the other cleanups
- use comctl32.dll v6 to get the controls to look modern
- add package dependency on directxtex_desktop_win10
- updated the package version for C++ WinRT to latest
- fixed all compiler warnings
- removed unneeded casts
- reformatted code per our samples conventions
- some re-refactoring cleanup across the files
- in params to const &, members to const when possible, etc.
- added comment about enabling SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
- reduce use of macros (windows.h macros), converted to explicit use of W API methods
- convert C style casts to C++